### PR TITLE
Fix relative links for root navigation

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,9 +10,9 @@
 
   <header class="site-header">
     <div class="wrapper">
-      <h1><a href="/">キミトーク開発記録</a></h1>
+      <h1><a href="{{ '/' | relative_url }}">キミトーク開発記録</a></h1>
       <nav>
-        <a href="/">Home</a>
+        <a href="{{ '/' | relative_url }}">Home</a>
         <a href="#about">About</a>
         <a href="#contact">Contact</a>
       </nav>


### PR DESCRIPTION
## Summary
- update navigation links to use `relative_url` for consistent baseurl handling

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684052f18b0883268204af6432532890